### PR TITLE
feat(platform): added platform check for determining types of widget…

### DIFF
--- a/lib/core/common/ui/components/flex_model_sheet_page.dart
+++ b/lib/core/common/ui/components/flex_model_sheet_page.dart
@@ -1,0 +1,79 @@
+import 'dart:io' show Platform;
+
+import 'package:flex_workout_mobile/platforms.dart';
+import 'package:flutter/material.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+class FlexModalSheetPage<T> extends Page<T> {
+  FlexModalSheetPage({
+    required this.child,
+    super.key,
+    super.name,
+    super.arguments,
+    super.restorationId,
+    this.maintainState = true,
+    this.barrierDismissible = true,
+    this.swipeDismissible = false,
+    this.fullscreenDialog = false,
+    this.barrierLabel,
+    this.barrierColor = Colors.black54,
+    this.transitionDuration = const Duration(milliseconds: 300),
+    this.transitionCurve = Curves.fastEaseInToSlowEaseOut,
+    this.swipeDismissSensitivity = const SwipeDismissSensitivity(),
+  });
+
+  final Widget child;
+  final bool maintainState;
+  final bool fullscreenDialog;
+  final Color? barrierColor;
+  final bool barrierDismissible;
+  final String? barrierLabel;
+  final bool swipeDismissible;
+  final Duration transitionDuration;
+  final Curve transitionCurve;
+  final SwipeDismissSensitivity swipeDismissSensitivity;
+
+  final p = P();
+
+  RouteSettings getModalSheetPage() {
+    if (Platform.isIOS) {
+      return CupertinoModalSheetPage<T>(
+        child: child,
+        name: name,
+        arguments: arguments,
+        restorationId: restorationId,
+        maintainState: maintainState,
+        barrierDismissible: barrierDismissible,
+        swipeDismissible: swipeDismissible,
+        fullscreenDialog: fullscreenDialog,
+        barrierLabel: barrierLabel,
+        barrierColor: barrierColor,
+        transitionDuration: transitionDuration,
+        transitionCurve: transitionCurve,
+        swipeDismissSensitivity: swipeDismissSensitivity,
+      );
+    } else {
+      return ModalSheetPage(
+        child: child,
+        name: name,
+        arguments: arguments,
+        restorationId: restorationId,
+        maintainState: maintainState,
+        barrierDismissible: barrierDismissible,
+        swipeDismissible: swipeDismissible,
+        fullscreenDialog: fullscreenDialog,
+        barrierLabel: barrierLabel,
+        barrierColor: barrierColor,
+        transitionDuration: transitionDuration,
+        transitionCurve: transitionCurve,
+        swipeDismissSensitivity: swipeDismissSensitivity,
+      );
+    }
+  }
+
+  @override
+  Route<T> createRoute(BuildContext context) {
+    // TODO: implement createRoute
+    throw UnimplementedError();
+  }
+}

--- a/lib/core/config/router.dart
+++ b/lib/core/config/router.dart
@@ -20,6 +20,7 @@ import 'package:flex_workout_mobile/features/tracker/ui/components/exercise_sele
 import 'package:flex_workout_mobile/features/tracker/ui/screens/exercise_selection_screen.dart';
 import 'package:flex_workout_mobile/features/tracker/ui/screens/normal_set_sheet.dart';
 import 'package:flex_workout_mobile/features/tracker/ui/screens/tracker_screen.dart';
+import 'package:flex_workout_mobile/platforms.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_swipe_action_cell/core/swipe_action_navigator_observer.dart';
 import 'package:go_router/go_router.dart';
@@ -45,11 +46,7 @@ final router = GoRouter(
         GoRoute(
           path: TrackerScreen.routePath,
           name: TrackerScreen.routeName,
-          pageBuilder: (context, state) => CupertinoModalSheetPage(
-            swipeDismissible: true,
-            barrierColor: context.colors.overlay,
-            child: const TrackerScreenModal(nestedNavigator: TrackerScreen()),
-          ),
+          pageBuilder: P.trackerScreenPageBuilder,
           routes: [
             GoRoute(
               path: ExerciseSelectionScreen.routePath,

--- a/lib/main_dev.dart
+++ b/lib/main_dev.dart
@@ -1,11 +1,14 @@
 import 'package:flex_workout_mobile/app.dart';
 import 'package:flex_workout_mobile/bootstrap.dart';
 import 'package:flex_workout_mobile/flavors.dart';
+import 'package:flex_workout_mobile/platforms.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 Future<void> main() async {
   F.appFlavor = Flavor.dev;
+
+  P();
 
   runApp(
     UncontrolledProviderScope(

--- a/lib/platforms.dart
+++ b/lib/platforms.dart
@@ -1,0 +1,48 @@
+import 'dart:io' show Platform;
+import 'package:flex_workout_mobile/core/extensions/ui_extensions.dart';
+import 'package:flex_workout_mobile/features/tracker/ui/screens/tracker_screen.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:smooth_sheets/smooth_sheets.dart';
+
+enum Platforms {
+  ios,
+  android,
+}
+
+class P {
+  /// Constructor
+  P() {
+    if (Platform.isIOS) {
+      appPlatform = Platforms.ios;
+      trackerScreenPageBuilder = (context, state) => CupertinoModalSheetPage(
+            swipeDismissible: true,
+            barrierColor: context.colors.overlay,
+            child: const TrackerScreenModal(nestedNavigator: TrackerScreen()),
+          );
+    } else if (Platform.isAndroid) {
+      appPlatform = Platforms.android;
+      trackerScreenPageBuilder = (context, state) => ModalSheetPage(
+            swipeDismissible: true,
+            barrierColor: context.colors.overlay,
+            child: const TrackerScreenModal(nestedNavigator: TrackerScreen()),
+          );
+    } else {
+      appPlatform = Platforms.ios;
+      trackerScreenPageBuilder = (context, state) => CupertinoModalSheetPage(
+            swipeDismissible: true,
+            barrierColor: context.colors.overlay,
+            child: const TrackerScreenModal(nestedNavigator: TrackerScreen()),
+          );
+    }
+  }
+
+  /// App Platform Type
+  static Platforms? appPlatform;
+
+  /// Widgets
+  /// - Page Builders
+  static Page<dynamic> Function(BuildContext, GoRouterState)?
+      trackerScreenPageBuilder;
+}

--- a/lib/platforms.dart
+++ b/lib/platforms.dart
@@ -42,7 +42,7 @@ class P {
   static Platforms? appPlatform;
 
   /// Widgets
-  /// - Page Builders
+  // - Page Builders
   static Page<dynamic> Function(BuildContext, GoRouterState)?
       trackerScreenPageBuilder;
 }


### PR DESCRIPTION
Widget and animation pre-settings depending on the platform. The goal is to set these widgets and animations before the app runs to determine any differences that are commonly used or expected on different platforms.

Current platforms:
- iOS
- Android
- Else - settings are the same as iOS

Created a new object, P. P has an enum and widget variables to use throughout the app depending on the platform the user runs the app on.  The constructor runs before the app is launched in the flavored main files (currently only main-dev).

Currently, it only changes the modal page type used for the tracker screen page builder.
- iOS - cupertino modal sheet page
- Android - modal sheet page
